### PR TITLE
add executableproduct for bzip2

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -48,6 +48,7 @@ platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products = prefix -> [
+    ExecutableProduct(prefix,"bzip2", :bzip2),
     LibraryProduct(prefix,"libbz2", :libbzip2),
 ]
 


### PR DESCRIPTION
Part of the freetype2 error in ffmpeg, with Bzip2Builder as a dep:
```
[18:38:58] Package dependency requirement 'freetype2 >= 9.10.3' could not be satisfied.
[18:38:58] Package 'freetype2' has version '2.10.0', required version is '>= 9.10.3'
[18:39:00] Package bzip2 was not found in the pkg-config search path.
[18:39:00] Perhaps you should add the directory containing `bzip2.pc'
[18:39:00] to the PKG_CONFIG_PATH environment variable
[18:39:00] Package 'bzip2', required by 'freetype2', not found
[18:39:00] ERROR: freetype2 not found using pkg-config
```